### PR TITLE
feat: persist chat history across sessions

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,15 @@
 <div class="chat-card">
   <h2>LLaMA Local</h2>
 
+  <div class="history">
+    <ng-container *ngFor="let m of llama.messages()">
+      <div *ngIf="m.role !== 'system'" [ngClass]="m.role">
+        <strong>{{ m.role === 'user' ? 'Você' : 'Narrador' }}:</strong>
+        <pre class="bubble">{{ m.content }}</pre>
+      </div>
+    </ng-container>
+  </div>
+
   <form (ngSubmit)="send()" class="row">
     <textarea
       [(ngModel)]="prompt"
@@ -9,14 +18,12 @@
       rows="4"
     ></textarea>
 
-    <button type="submit" [disabled]="loading()">Enviar</button>
+    <div class="actions">
+      <button type="submit" [disabled]="loading()">Enviar</button>
+      <button type="button" (click)="reset()">Resetar</button>
+    </div>
   </form>
 
   <div class="status" *ngIf="loading()">Gerando resposta...</div>
   <div class="error" *ngIf="error()">{{ error() }}</div>
-
-  <div class="reply" *ngIf="reply()">
-    <h3>Resposta</h3>
-    <pre>{{ reply() }}</pre>
-  </div>
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -8,6 +8,23 @@
   gap: 12px;
 }
 
+.history {
+  display: grid;
+  gap: 8px;
+
+  .bubble {
+    display: inline-block;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: #f3f4f6;
+    white-space: pre-wrap;
+  }
+
+  .user {
+    text-align: right;
+  }
+}
+
 .row {
   display: grid;
   gap: 8px;
@@ -38,4 +55,11 @@
 
 .status { font-size: 14px; color: #374151; }
 .error  { color: #b91c1c; }
-.reply  { white-space: pre-wrap; }
+.actions {
+  display: flex;
+  gap: 8px;
+
+  button[type='button'] {
+    background: #6b7280;
+  }
+}

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -14,16 +14,10 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'rpg-ia' title`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('rpg-ia');
-  });
-
-  it('should render title', () => {
+  it('should render header', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, rpg-ia');
+    expect(compiled.querySelector('h2')?.textContent).toContain('LLaMA Local');
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -16,22 +16,23 @@ export class AppComponent {
   prompt = '';
   loading = signal(false);
   error = signal<string | null>(null);
-  reply = signal('');
-
-  constructor(private readonly llama: LlamaService) {}
+  constructor(public readonly llama: LlamaService) {}
 
   async send() {
     if (!this.prompt.trim()) return;
     this.loading.set(true);
     this.error.set(null);
-    this.reply.set('');
     try {
-      const res = await this.llama.chat(this.prompt);
-      this.reply.set(res);
+      await this.llama.chat(this.prompt);
+      this.prompt = '';
     } catch (e: any) {
       this.error.set(e?.message ?? 'Erro ao conectar no Ollama');
     } finally {
       this.loading.set(false);
     }
+  }
+
+  reset() {
+    this.llama.reset();
   }
 }


### PR DESCRIPTION
## Summary
- persist conversation history in `LlamaService` using signals and localStorage
- expose and render message log with reset option in the app component
- update unit test to match new header

## Testing
- `npm run build`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68af2a5d87348333957cef62de34dd9a