### PR TITLE
feat: add initial RPG scenario on startup

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
@@ -12,11 +12,25 @@ import { LlamaService } from './llama.service';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   prompt = '';
   loading = signal(false);
   error = signal<string | null>(null);
   constructor(public readonly llama: LlamaService) {}
+
+  async ngOnInit() {
+    if (this.llama.messages().length === 1) {
+      this.loading.set(true);
+      this.error.set(null);
+      try {
+        await this.llama.startScenario();
+      } catch (e: any) {
+        this.error.set(e?.message ?? 'Erro ao conectar no Ollama');
+      } finally {
+        this.loading.set(false);
+      }
+    }
+  }
 
   async send() {
     if (!this.prompt.trim()) return;

--- a/src/app/llama.service.ts
+++ b/src/app/llama.service.ts
@@ -91,6 +91,17 @@ private readonly baseUrl = 'http://localhost:11434/api';
     }
   }
 
+  async startScenario(): Promise<void> {
+    const content = await this.generate(
+      'Crie um cenário inicial de uma aventura e pergunte ao jogador o que deseja fazer.'
+    );
+    this.messages.update((msgs) => [
+      ...msgs,
+      { role: 'assistant', content },
+    ]);
+    this.save();
+  }
+
   reset() {
     this.messages.set([{ role: 'system', content: this.narratorPrompt }]);
     this.save();


### PR DESCRIPTION
## Summary
- start new adventures automatically with `startScenario` helper
- load initial scene on app start when no previous messages

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68af2fb1fbe483338aeb0128000658e5